### PR TITLE
feat: allow using the previous cache/items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -165,6 +165,36 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 	return item.Object, time.Time{}, true
 }
 
+// GetEvenIfExpired returns an item and its expiration time from the cache.
+// It returns the item, the expiration time if one is set (if the item
+// never expires a zero value for time.Time is returned), and a bool indicating
+// whether the key was found.
+func (c *cache) GetEvenIfExpired(k string) (interface{}, time.Time, bool) {
+	c.mu.RLock()
+	// "Inlining" of get and Expired
+	item, found := c.items[k]
+	if !found {
+		c.mu.RUnlock()
+		return nil, time.Time{}, true
+	}
+
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			c.mu.RUnlock()
+			return item.Object, time.Unix(0, item.Expiration), true
+		}
+
+		// Return the item and the expiration time
+		c.mu.RUnlock()
+		return item.Object, time.Unix(0, item.Expiration), false
+	}
+
+	// If expiration <= 0 (i.e. no expiration time set) then return the item
+	// and a zeroed time.Time
+	c.mu.RUnlock()
+	return item.Object, time.Time{}, false
+}
+
 func (c *cache) get(k string) (interface{}, bool) {
 	item, found := c.items[k]
 	if !found {


### PR DESCRIPTION
Allow using the expired cache if any issue. 
Added a new function named `GetEventIfExpired` which has pretty much the same logic as the `GetWithExpiration` but it is returning the expired object. 